### PR TITLE
feat: IMAP integration, agentic email extraction, backlink fix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "FOUNDATION"
 version = "0.16.0"
 dependencies = [
+ "async-imap",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -16,9 +17,12 @@ dependencies = [
  "futures-util",
  "hostname",
  "image",
+ "imap",
  "lazy_static",
  "libc",
  "llama-cpp-2",
+ "mailparse",
+ "native-tls",
  "pdf-extract",
  "reqwest",
  "rhai",
@@ -169,6 +173,12 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -188,10 +198,21 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -207,6 +228,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +251,29 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "async-imap"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca726c61b73c471f531b65e83e161776ba62c2b6ba4ec73d51fad357009ed00a"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "imap-proto 0.16.7",
+ "log",
+ "nom 7.1.3",
+ "pin-project",
+ "pin-utils",
+ "self_cell",
+ "stop-token",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -244,7 +300,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -255,14 +311,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.2",
 ]
@@ -357,7 +413,7 @@ dependencies = [
  "aligned",
  "anyhow",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.6",
  "log",
  "num-rational",
  "num-traits",
@@ -375,7 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
 dependencies = [
  "anyhow",
- "arrayvec",
+ "arrayvec 0.7.6",
  "log",
  "nom 8.0.0",
  "num-rational",
@@ -388,7 +444,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -445,6 +501,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -574,7 +636,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -612,6 +674,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "built"
@@ -807,6 +875,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64 0.22.1",
+ "encoding_rs",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +943,22 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -1120,6 +1214,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -1417,6 +1517,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1432,7 +1538,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1634,6 +1740,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1829,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2481,6 +2603,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "imap"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c617c55def8c42129e0dd503f11d7ee39d73f5c7e01eff55768b3879ff1d107d"
+dependencies = [
+ "base64 0.13.1",
+ "bufstream",
+ "chrono",
+ "imap-proto 0.10.2",
+ "lazy_static",
+ "native-tls",
+ "nom 5.1.3",
+ "regex",
+]
+
+[[package]]
+name = "imap-proto"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a6def1d5ac8975d70b3fd101d57953fe3278ef2ee5d7816cba54b1d1dfc22f"
+dependencies = [
+ "nom 5.1.3",
+]
+
+[[package]]
+name = "imap-proto"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f6af35c6a517aea5c72314abe90134980d2ae6a763809b50c208b3e429d71f"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2903,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,6 +3120,17 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mailparse"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
 
 [[package]]
 name = "markup5ever"
@@ -3193,6 +3373,17 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
 
 [[package]]
 name = "nom"
@@ -3918,6 +4109,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,6 +4398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4333,7 +4550,7 @@ dependencies = [
  "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.6",
  "av-scenechange",
  "av1-grain",
  "bitstream-io",
@@ -4806,6 +5023,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,6 +5379,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stop-token"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
+dependencies = [
+ "async-channel 1.9.0",
+ "cfg-if",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "string_cache"
@@ -7522,7 +7757,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-lite",
  "hex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,10 @@ tantivy = "0.22"
 llama-cpp-2 = { version = "0.1.143", features = ["metal", "sampler"] }
 encoding_rs = "0.8"
 rhai = { version = "^1", features = ["sync"] }
+async-imap = { version = "0.10", default-features = false, features = ["runtime-tokio"] }
+imap = { version = "2", default-features = false, features = ["tls"] }
+native-tls = "0.2"
+mailparse = "0.15"
 
 [dev-dependencies]
 tempfile = "3.8"  # Temporary files for tests

--- a/src-tauri/src/ai/functions/definitions.rs
+++ b/src-tauri/src/ai/functions/definitions.rs
@@ -772,7 +772,7 @@ Example — find all active Tasks whose due date is before this Project's deadli
                 Parameter {
                     name: "conversation_iri".to_string(),
                     param_type: "string".to_string(),
-                    description: "IRI of the conversation whose blackboard to inspect. Required when called outside the Foundation chat engine (e.g. via Claude Desktop MCP).".to_string(),
+                    description: "IRI of the conversation whose blackboard to inspect. Optional — if omitted, the most recent conversation is used automatically.".to_string(),
                     required: false,
                     schema: None,
                 },
@@ -801,7 +801,7 @@ Example — find all active Tasks whose due date is before this Project's deadli
                 Parameter {
                     name: "conversation_iri".to_string(),
                     param_type: "string".to_string(),
-                    description: "IRI of the conversation whose blackboard to add the widget to. Required when called outside the Foundation chat engine.".to_string(),
+                    description: "IRI of the conversation whose blackboard to add the widget to. Optional — if omitted, the most recent conversation is used automatically.".to_string(),
                     required: false,
                     schema: None,
                 },

--- a/src-tauri/src/ai/functions/mod.rs
+++ b/src-tauri/src/ai/functions/mod.rs
@@ -379,24 +379,62 @@ fn run_automation_tool(conn: &Connection, args: &Value, app: Option<&tauri::AppH
     }
 }
 
+fn find_most_recent_conversation_iri(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT c.subject FROM triples c
+         LEFT JOIN (
+             SELECT tp.object AS conv, MAX(ts.object_value) AS last_msg
+             FROM triples tp
+             JOIN triples ts ON ts.subject = tp.subject
+                 AND ts.predicate = 'foundation:sentAt'
+                 AND ts.retracted = 0
+             WHERE tp.predicate = 'foundation:partOfConversation'
+               AND tp.retracted = 0
+             GROUP BY tp.object
+         ) m ON m.conv = c.subject
+         LEFT JOIN triples ca ON ca.subject = c.subject
+             AND ca.predicate = 'foundation:createdAt'
+             AND ca.retracted = 0
+         WHERE c.predicate = 'rdf:type'
+           AND c.object = 'foundation:AIConversation'
+           AND c.retracted = 0
+         ORDER BY COALESCE(m.last_msg, ca.object_value, '') DESC, c.subject DESC
+         LIMIT 1",
+        [],
+        |row| row.get::<_, String>(0),
+    ).ok()
+}
+
+fn resolve_conversation_iri(
+    conn: &Connection,
+    args: &Value,
+    conversation_id: Option<&str>,
+) -> Result<String, String> {
+    if let Some(c) = args["conversation_iri"].as_str().filter(|s| !s.is_empty()) {
+        return Ok(c.to_string());
+    }
+    if let Some(c) = conversation_id {
+        return Ok(c.to_string());
+    }
+    find_most_recent_conversation_iri(conn)
+        .ok_or_else(|| "No conversations exist; conversation_iri could not be inferred".to_string())
+}
+
 fn list_blackboard_widgets_tool(
     conn: &Connection,
     args: &Value,
     conversation_id: Option<&str>,
 ) -> ToolResult {
-    let conv_iri = args["conversation_iri"].as_str()
-        .filter(|s| !s.is_empty())
-        .or(conversation_id);
-
-    let conv_iri = match conv_iri {
-        Some(c) => c,
-        None => return ToolResult {
+    let conv_iri = match resolve_conversation_iri(conn, args, conversation_id) {
+        Ok(c) => c,
+        Err(e) => return ToolResult {
             success: false,
             result: None,
-            error: Some("conversation_iri is required when called outside the Foundation chat engine".to_string()),
+            error: Some(e),
             concept: None,
         },
     };
+    let conv_iri = conv_iri.as_str();
 
     let widgets = match crate::commands::widget::owl_get_widgets_for_conversation(conn, conv_iri) {
         Ok(w) => w,
@@ -443,16 +481,12 @@ fn add_widget_to_blackboard_tool(
         },
     };
 
-    let conv_iri = args["conversation_iri"].as_str()
-        .filter(|s| !s.is_empty())
-        .or(conversation_id);
-
-    let conv_iri = match conv_iri {
-        Some(c) => c.to_string(),
-        None => return ToolResult {
+    let conv_iri = match resolve_conversation_iri(conn, args, conversation_id) {
+        Ok(c) => c,
+        Err(e) => return ToolResult {
             success: false,
             result: None,
-            error: Some("conversation_iri is required when called outside the Foundation chat engine".to_string()),
+            error: Some(e),
             concept: None,
         },
     };

--- a/src-tauri/src/ai/providers.rs
+++ b/src-tauri/src/ai/providers.rs
@@ -507,8 +507,11 @@ impl ClaudeProvider {
                 "cache_control": { "type": "ephemeral" }
             }])),
             temperature: request.temperature,
-            tools: None,
-            tool_choice: None,
+            tools: request.tools.as_ref().map(|tools| {
+                tools.iter().map(|t| serde_json::to_value(t).unwrap_or_default()).collect()
+            }),
+            tool_choice: request.tool_choice.as_ref()
+                .map(|tc| serde_json::to_value(tc).unwrap_or_default()),
         }).map_err(|e| format!("Failed to serialize request: {}", e))?;
 
         let http_response = self.client
@@ -533,14 +536,23 @@ impl ClaudeProvider {
             .map_err(|e| format!("Failed to parse response: {}", e))?;
 
         let stop_reason = body["stop_reason"].as_str().map(String::from);
-        let content = body["content"]
-            .as_array()
-            .and_then(|blocks| blocks.iter()
-                .find(|b| b["type"] == "text")
-                .and_then(|b| b["text"].as_str())
-            )
+
+        let blocks = body["content"].as_array().map(|v| v.as_slice()).unwrap_or(&[]);
+        let content = blocks.iter()
+            .find(|b| b["type"] == "text")
+            .and_then(|b| b["text"].as_str())
             .unwrap_or("")
             .to_string();
+        let tool_calls: Vec<ToolCall> = blocks.iter()
+            .filter(|b| b["type"] == "tool_use")
+            .filter_map(|b| {
+                Some(ToolCall {
+                    id: b["id"].as_str()?.to_string(),
+                    name: b["name"].as_str()?.to_string(),
+                    input: b["input"].clone(),
+                })
+            })
+            .collect();
 
         let usage = body["usage"].as_object().map(|u| UsageInfo {
             input_tokens: u["input_tokens"].as_u64().unwrap_or(0) as u32,
@@ -551,7 +563,7 @@ impl ClaudeProvider {
 
         Ok(GenerateResponse {
             content,
-            tool_calls: vec![],
+            tool_calls,
             thinking_blocks: vec![],
             stop_reason,
             usage,

--- a/src-tauri/src/commands/entity/individual.rs
+++ b/src-tauri/src/commands/entity/individual.rs
@@ -527,6 +527,7 @@ pub(super) fn get_individual_data(conn: &Connection, individual_id: &str, groups
             let resolved_label = b.source_class.as_deref()
                 .and_then(|cls| cached.and_then(|(_, _, dls)| {
                     dls.iter().find(|dl| dl.domain == cls)
+                        .or_else(|| dls.iter().find(|dl| dl.domain == "owl:Thing"))
                 }))
                 .map(|dl| dl.inverse_label.as_deref().unwrap_or(&dl.forward_label).to_string())
                 .or_else(|| cached.map(|(l, _, _)| l.clone()))

--- a/src-tauri/src/commands/imap.rs
+++ b/src-tauri/src/commands/imap.rs
@@ -1,0 +1,340 @@
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+
+use crate::eavto::Connection;
+use crate::owl::{DbExecutor, Individual, Object};
+
+const CONNECTION_TIMEOUT_SECS: u64 = 15;
+const DEFAULT_SYNC_HISTORY_LIMIT: i64 = 50;
+
+fn str_lit(v: impl Into<String>) -> Object {
+    Object::Literal { value: v.into(), datatype: Some("xsd:string".to_string()), language: None }
+}
+
+fn bool_lit(v: bool) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:boolean".to_string()), language: None }
+}
+
+fn set_prop(
+    conn: &mut Connection,
+    iri: &str,
+    prop: &str,
+    values: Vec<Object>,
+    origin: &str,
+) -> Result<(), String> {
+    Individual::clear_property(conn, iri, prop, origin).ok();
+    Individual::new(iri)
+        .add_property(conn, prop, values, origin)
+        .map_err(|e| format!("{}: {}", prop, e))
+}
+
+fn get_int(conn: &Connection, iri: &str, prop: &str, default: i64) -> i64 {
+    crate::owl::get_literal_property(conn, iri, prop)
+        .unwrap_or_default()
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImapAccountInput {
+    pub label: String,
+    pub host: String,
+    pub port: u16,
+    pub use_tls: bool,
+    pub username: String,
+    pub password: String,
+    pub sync_interval_minutes: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ImapAccountSummary {
+    pub iri: String,
+    pub label: String,
+    pub host: String,
+    pub port: i64,
+    pub use_tls: bool,
+    pub username: String,
+    pub sync_interval_minutes: i64,
+    pub last_error: Option<String>,
+    pub is_connected: bool,
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__save_account(
+    _app: AppHandle,
+    account_iri: Option<String>,
+    input: ImapAccountInput,
+    executor: State<'_, DbExecutor>,
+) -> Result<String, String> {
+    executor.write(move |conn| {
+        let ts = chrono::Utc::now().timestamp_millis();
+        let iri = account_iri.unwrap_or_else(|| format!("foundation:IMAPAccount_{}", ts));
+        let ind = Individual::new(&iri);
+
+        ind.assert(conn, "foundation:IMAPAccount", &input.label, "alternate_email", "imap")
+            .map_err(|e| format!("assert: {}", e))?;
+
+        set_prop(conn, &iri, "foundation:imapHost", vec![str_lit(&input.host)], "imap")?;
+        set_prop(conn, &iri, "foundation:imapPort", vec![Object::Integer(input.port as i64)], "imap")?;
+        set_prop(conn, &iri, "foundation:imapUseTLS", vec![bool_lit(input.use_tls)], "imap")?;
+        set_prop(conn, &iri, "foundation:imapUsername", vec![str_lit(&input.username)], "imap")?;
+        set_prop(conn, &iri, "foundation:syncInterval", vec![Object::Integer(input.sync_interval_minutes)], "imap")?;
+        set_prop(conn, &iri, "foundation:hasStatus", vec![Object::Iri("foundation:Pending".to_string())], "imap")?;
+
+        let existing_cred = crate::owl::get_iri_property(conn, &iri, "foundation:hasCredential")
+            .ok()
+            .flatten();
+
+        if !input.password.is_empty() {
+            if let Some(old_cred) = &existing_cred {
+                Individual::retract(conn, old_cred, "imap").ok();
+            }
+            let cred_iri = format!("foundation:IMAPCredential_{}", ts);
+            let cred = Individual::new(&cred_iri);
+            cred.assert(conn, "foundation:UsernamePasswordCredential", &cred_iri, "vpn_key", "imap")
+                .map_err(|e| format!("credential: {}", e))?;
+            cred.add_property(conn, "foundation:credentialUsername", vec![str_lit(&input.username)], "imap")
+                .map_err(|e| format!("credentialUsername: {}", e))?;
+            cred.add_property(conn, "foundation:credentialValue", vec![str_lit(&input.password)], "imap")
+                .map_err(|e| format!("credentialValue: {}", e))?;
+            set_prop(conn, &iri, "foundation:hasCredential", vec![Object::Iri(cred_iri)], "imap")?;
+        } else if existing_cred.is_none() {
+            return Err("Senha obrigatória para nova conta".to_string());
+        }
+
+        Ok(iri)
+    }).await
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__get_accounts(
+    executor: State<'_, DbExecutor>,
+) -> Result<Vec<ImapAccountSummary>, String> {
+    executor.read(move |conn| {
+        let iris = crate::owl::find_entities_with_property(conn, "rdf:type", "foundation:IMAPAccount")
+            .map_err(|e| e.to_string())?;
+
+        iris.into_iter().map(|iri| {
+            let label = crate::owl::get_literal_property(conn, &iri, "rdfs:label")
+                .unwrap_or_default().unwrap_or_else(|| iri.clone());
+            let host = crate::owl::get_literal_property(conn, &iri, "foundation:imapHost")
+                .unwrap_or_default().unwrap_or_default();
+            let port = get_int(conn, &iri, "foundation:imapPort", 993);
+            let use_tls = crate::owl::get_literal_property(conn, &iri, "foundation:imapUseTLS")
+                .unwrap_or_default().map(|v| v == "true").unwrap_or(true);
+            let username = crate::owl::get_literal_property(conn, &iri, "foundation:imapUsername")
+                .unwrap_or_default().unwrap_or_default();
+            let sync_interval_minutes = get_int(conn, &iri, "foundation:syncInterval", 15);
+            let last_error = crate::owl::get_literal_property(conn, &iri, "foundation:lastConnectionError")
+                .unwrap_or_default();
+            let is_connected = crate::owl::get_literal_property(conn, &iri, "foundation:isConnected")
+                .unwrap_or_default().map(|v| v == "true").unwrap_or(false);
+
+            Ok(ImapAccountSummary {
+                iri, label, host, port, use_tls, username,
+                sync_interval_minutes, last_error, is_connected,
+            })
+        }).collect()
+    }).await
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__test_connection(
+    host: String,
+    port: u16,
+    use_tls: bool,
+    username: String,
+    password: String,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || -> Result<String, String> {
+        connect_and_login(&host, port, use_tls, &username, &password)?;
+        Ok(format!("Conexão com {}:{} bem-sucedida.", host, port))
+    }).await.map_err(|e| format!("Task error: {}", e))?
+}
+
+pub fn connect_and_login(
+    host: &str,
+    port: u16,
+    use_tls: bool,
+    username: &str,
+    password: &str,
+) -> Result<(), String> {
+    let addr = (host, port);
+    let timeout = std::time::Duration::from_secs(CONNECTION_TIMEOUT_SECS);
+
+    if use_tls {
+        let tcp = std::net::TcpStream::connect(addr)
+            .map_err(|e| format!("Conexão TCP falhou: {}", e))?;
+        tcp.set_read_timeout(Some(timeout)).ok();
+        tcp.set_write_timeout(Some(timeout)).ok();
+        let tls = native_tls::TlsConnector::new()
+            .map_err(|e| format!("TLS init: {}", e))?;
+        let tls_stream = tls.connect(host, tcp)
+            .map_err(|e| format!("TLS handshake falhou: {}", e))?;
+        let mut session = imap::Client::new(tls_stream)
+            .login(username, password)
+            .map_err(|(e, _)| format!("Login falhou: {}", e))?;
+        session.logout().ok();
+    } else {
+        let stream = std::net::TcpStream::connect(addr)
+            .map_err(|e| format!("Conexão falhou: {}", e))?;
+        stream.set_read_timeout(Some(timeout)).ok();
+        stream.set_write_timeout(Some(timeout)).ok();
+        let mut session = imap::Client::new(stream)
+            .login(username, password)
+            .map_err(|(e, _)| format!("Login falhou: {}", e))?;
+        session.logout().ok();
+    }
+    Ok(())
+}
+
+pub fn list_imap_folders(
+    host: &str,
+    port: u16,
+    use_tls: bool,
+    username: &str,
+    password: &str,
+) -> Result<Vec<String>, String> {
+    let addr = (host, port);
+    let timeout = std::time::Duration::from_secs(CONNECTION_TIMEOUT_SECS);
+
+    let names = if use_tls {
+        let tcp = std::net::TcpStream::connect(addr)
+            .map_err(|e| format!("TCP: {}", e))?;
+        tcp.set_read_timeout(Some(timeout)).ok();
+        tcp.set_write_timeout(Some(timeout)).ok();
+        let tls = native_tls::TlsConnector::new().map_err(|e| e.to_string())?;
+        let tls_stream = tls.connect(host, tcp).map_err(|e| format!("TLS: {}", e))?;
+        let mut session = imap::Client::new(tls_stream)
+            .login(username, password)
+            .map_err(|(e, _)| format!("login: {}", e))?;
+        let names = session
+            .list(Some(""), Some("*"))
+            .map_err(|e| e.to_string())?
+            .iter()
+            .map(|n| n.name().to_string())
+            .collect::<Vec<_>>();
+        session.logout().ok();
+        names
+    } else {
+        let stream = std::net::TcpStream::connect(addr)
+            .map_err(|e| format!("TCP: {}", e))?;
+        stream.set_read_timeout(Some(timeout)).ok();
+        stream.set_write_timeout(Some(timeout)).ok();
+        let mut session = imap::Client::new(stream)
+            .login(username, password)
+            .map_err(|(e, _)| format!("login: {}", e))?;
+        let names = session
+            .list(Some(""), Some("*"))
+            .map_err(|e| e.to_string())?
+            .iter()
+            .map(|n| n.name().to_string())
+            .collect::<Vec<_>>();
+        session.logout().ok();
+        names
+    };
+
+    Ok(names)
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__list_folders(
+    host: String,
+    port: u16,
+    use_tls: bool,
+    username: String,
+    password: String,
+) -> Result<Vec<String>, String> {
+    tokio::task::spawn_blocking(move || -> Result<Vec<String>, String> {
+        let folders = list_imap_folders(&host, port, use_tls, &username, &password)?;
+        Ok(folders)
+    }).await.map_err(|e| format!("Task error: {}", e))?
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__save_monitored_folders(
+    account_iri: String,
+    folders: Vec<String>,
+    executor: State<'_, DbExecutor>,
+) -> Result<(), String> {
+    executor.write(move |conn| {
+        Individual::clear_property(conn, &account_iri, "foundation:imapMonitoredFolders", "imap").ok();
+        if !folders.is_empty() {
+            let values: Vec<Object> = folders.iter().map(|f| str_lit(f)).collect();
+            Individual::new(&account_iri)
+                .add_property(conn, "foundation:imapMonitoredFolders", values, "imap")
+                .map_err(|e| format!("folders: {}", e))?;
+        }
+        Ok(String::new())
+    }).await.map(|_| ())
+}
+
+#[derive(Debug, Serialize)]
+pub struct SyncLogEntry {
+    pub iri: String,
+    pub started_at: String,
+    pub emails_imported: i64,
+    pub error: Option<String>,
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__get_sync_history(
+    account_iri: String,
+    limit: Option<i64>,
+    executor: State<'_, DbExecutor>,
+) -> Result<Vec<SyncLogEntry>, String> {
+    executor.read(move |conn| {
+        let max = limit.unwrap_or(DEFAULT_SYNC_HISTORY_LIMIT);
+        let iris = crate::owl::find_entities_with_property(conn, "foundation:syncForAccount", &account_iri)
+            .map_err(|e| e.to_string())?;
+
+        let mut entries: Vec<SyncLogEntry> = iris.into_iter().filter_map(|iri| {
+            let started_at = crate::owl::get_literal_property(conn, &iri, "foundation:syncStartedAt")
+                .unwrap_or_default().unwrap_or_default();
+            let emails_imported = crate::owl::get_literal_property(conn, &iri, "foundation:syncEmailsImported")
+                .unwrap_or_default()
+                .and_then(|s| s.parse::<i64>().ok())
+                .unwrap_or(0);
+            let error = crate::owl::get_literal_property(conn, &iri, "foundation:syncErrorMessage")
+                .unwrap_or_default();
+            Some(SyncLogEntry { iri, started_at, emails_imported, error })
+        }).collect();
+
+        entries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        entries.truncate(max as usize);
+        Ok(entries)
+    }).await
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__start_account_sync(
+    app: AppHandle,
+    account_iri: String,
+) -> Result<(), String> {
+    crate::imap::sync_worker::start_account_sync(app, account_iri).await;
+    Ok(())
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn imap__delete_account(
+    account_iri: String,
+    executor: State<'_, DbExecutor>,
+) -> Result<(), String> {
+    executor.write(move |conn| {
+        if let Ok(Some(cred_iri)) = crate::owl::get_iri_property(conn, &account_iri, "foundation:hasCredential") {
+            Individual::retract(conn, &cred_iri, "imap")
+                .map_err(|e| format!("credential: {}", e))?;
+        }
+        Individual::retract(conn, &account_iri, "imap")
+            .map_err(|e| format!("account: {}", e))?;
+        Ok(String::new())
+    }).await.map(|_| ())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod connector_package;
 pub mod automation;
 pub mod task;
 pub mod local_model;
+pub mod imap;
 
 pub use setup::*;
 pub use setup_ai::*;

--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -119,6 +119,7 @@ pub async fn initialize_app(
 
     tauri::async_runtime::spawn(crate::process_automation::scheduler::reload(app.clone()));
     tauri::async_runtime::spawn(crate::process_automation::task_scheduler::start(app.clone()));
+    tauri::async_runtime::spawn(crate::imap::sync_worker::start_imap_sync(app.clone()));
     super::log_backend("debug", &format!("[STARTUP] total_before_emit={}ms", t0.elapsed().as_millis()));
 
     let _ = app.emit("import-complete", ());

--- a/src-tauri/src/imap/ai_extraction.rs
+++ b/src-tauri/src/imap/ai_extraction.rs
@@ -1,0 +1,256 @@
+use crate::ai::providers::ClaudeProvider;
+use crate::ai::functions::get_available_tools;
+use crate::owl::{DbExecutor, Individual, Object};
+use crate::process_automation::agent_task::run_headless_tool_loop;
+use tauri::AppHandle;
+
+const ONTOLOGIST_AGENT: &str = "foundation:SoftwareAgent_1773313705318";
+const EXTRACTION_CONFIDENCE_THRESHOLD: f64 = 0.8;
+const MAX_EMAIL_BODY_CHARS: usize = 4000;
+const EXTRACTION_TIMEOUT_SECS: u64 = 120;
+const MAX_TOOL_LOOPS: usize = 8;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+struct ExtractionItem {
+    class_iri: String,
+    label: String,
+    #[serde(default)]
+    properties: std::collections::HashMap<String, String>,
+    confidence: f64,
+}
+
+pub async fn extract_email_entities(
+    _app: &AppHandle,
+    executor: &DbExecutor,
+    email_iri: String,
+    email_subject: String,
+    email_body: String,
+    email_from: String,
+) {
+    let config = match load_ontologist_config(executor).await {
+        Ok(c) => c,
+        Err(e) => {
+            crate::imap::log_error(&format!("extraction config: {}", e));
+            return;
+        }
+    };
+
+    let tools = get_available_tools()
+        .into_iter()
+        .filter(|t| matches!(t.name.as_str(), "search" | "describe_class"))
+        .map(|t| t.to_claude_tool())
+        .collect();
+
+    let provider = ClaudeProvider::with_model(config.0, config.1, config.3);
+    let prompt = build_extraction_prompt(&email_from, &email_subject, &email_body);
+
+    let response = match run_headless_tool_loop(
+        executor, &provider, config.2, prompt, tools, MAX_TOOL_LOOPS,
+    ).await {
+        Ok(r) => r,
+        Err(e) => {
+            crate::imap::log_error(&format!("extraction generate: {}", e));
+            return;
+        }
+    };
+
+    let items: Vec<ExtractionItem> = match parse_extraction_response(&response) {
+        Ok(items) => items,
+        Err(e) => {
+            crate::imap::log_error(&format!("extraction parse: {}", e));
+            return;
+        }
+    };
+
+    const BLOCKED_CLASSES: &[&str] = &[
+        "foundation:Email",
+        "foundation:EmailAddress",
+        "foundation:IMAPAccount",
+        "foundation:IMAPSyncLog",
+    ];
+
+    let items: Vec<ExtractionItem> = items.into_iter().filter(|item| {
+        if BLOCKED_CLASSES.contains(&item.class_iri.as_str()) {
+            crate::imap::log_error(&format!("extraction: blocked infrastructure class {}", item.class_iri));
+            false
+        } else {
+            true
+        }
+    }).collect();
+
+    if items.is_empty() {
+        return;
+    }
+
+    executor
+        .write(move |conn| {
+            let ts = chrono::Utc::now().timestamp_millis();
+            for (i, item) in items.iter().enumerate() {
+                let unique_id = ts + i as i64;
+                if item.confidence >= EXTRACTION_CONFIDENCE_THRESHOLD {
+                    let iri = format!("foundation:Extracted_{}", unique_id);
+                    persist_entity(conn, &iri, item, &email_iri).ok();
+                } else {
+                    persist_pending(conn, item, &email_iri, unique_id).ok();
+                }
+            }
+            Ok(String::new())
+        })
+        .await
+        .ok();
+}
+
+fn persist_entity(
+    conn: &mut crate::eavto::Connection,
+    iri: &str,
+    item: &ExtractionItem,
+    email_iri: &str,
+) -> Result<(), String> {
+    Individual::new(iri)
+        .assert(conn, &item.class_iri, &item.label, "smart_toy", "imap")
+        .map_err(|e| e.to_string())?;
+    for (prop, val) in &item.properties {
+        let obj = property_value_to_object(conn, prop, val);
+        Individual::new(iri)
+            .add_property(conn, prop, vec![obj], "imap")
+            .ok();
+    }
+    Individual::new(iri)
+        .add_property(conn, "foundation:derivedFromEmail", vec![Object::Iri(email_iri.to_string())], "imap")
+        .ok();
+    Ok(())
+}
+
+fn typed_lit(v: &str, dt: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some(dt.to_string()), language: None }
+}
+
+fn property_value_to_object(
+    conn: &crate::eavto::Connection,
+    prop: &str,
+    val: &str,
+) -> Object {
+    let range = crate::owl::get_iri_property(conn, prop, "rdfs:range")
+        .unwrap_or_default()
+        .unwrap_or_default();
+    match range.as_str() {
+        "xsd:dateTime" => typed_lit(val, "xsd:dateTime"),
+        "xsd:date" => typed_lit(val, "xsd:date"),
+        "xsd:boolean" => typed_lit(val, "xsd:boolean"),
+        "xsd:anyURI" => typed_lit(val, "xsd:anyURI"),
+        "xsd:integer" | "xsd:int" | "xsd:long"
+        | "xsd:nonNegativeInteger" | "xsd:positiveInteger"
+        | "xsd:decimal" | "xsd:float" | "xsd:double" =>
+            typed_lit(val, &range),
+        r if !r.is_empty() && !r.starts_with("xsd:") && !r.starts_with("rdfs:") =>
+            Object::Iri(val.to_string()),
+        _ => str_lit(val),
+    }
+}
+
+fn persist_pending(
+    conn: &mut crate::eavto::Connection,
+    item: &ExtractionItem,
+    email_iri: &str,
+    unique_id: i64,
+) -> Result<(), String> {
+    let iri = format!("foundation:PendingExtraction_{}", unique_id);
+    let payload = serde_json::to_string(item).map_err(|e| e.to_string())?;
+    Individual::new(&iri)
+        .assert(conn, "foundation:PendingExtraction", &item.label, "pending_actions", "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&iri)
+        .add_property(conn, "foundation:extractionEmail", vec![Object::Iri(email_iri.to_string())], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&iri)
+        .add_property(conn, "foundation:extractionPayload", vec![str_lit(&payload)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&iri)
+        .add_property(conn, "foundation:extractionConfidence", vec![decimal_lit(item.confidence)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&iri)
+        .add_property(conn, "foundation:hasStatus", vec![Object::Iri("foundation:Pending".to_string())], "imap")
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn str_lit(v: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:string".to_string()), language: None }
+}
+
+fn decimal_lit(v: f64) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:decimal".to_string()), language: None }
+}
+
+async fn load_ontologist_config(executor: &DbExecutor) -> Result<(String, String, String, u64), String> {
+    executor.read(move |conn| {
+        let service_iri = crate::owl::get_iri_property(conn, ONTOLOGIST_AGENT, "foundation:usesService")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Ontologist has no usesService".to_string())?;
+
+        let api_key_iri = crate::owl::get_iri_property(conn, &service_iri, "foundation:apiKey")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Ontologist service has no apiKey".to_string())?;
+
+        let api_key = crate::owl::get_literal_property(conn, &api_key_iri, "foundation:credentialValue")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "API key has no value".to_string())?;
+
+        let model_iri = crate::owl::get_iri_property(conn, ONTOLOGIST_AGENT, "foundation:usesModel")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Ontologist has no usesModel".to_string())?;
+
+        let model_id = crate::owl::get_literal_property(conn, &model_iri, "foundation:modelIdentifier")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Model has no modelIdentifier".to_string())?;
+
+        let base = crate::commands::chat::settings::load_base_system_prompt(conn);
+        let agent_prompt = crate::owl::get_literal_property(conn, ONTOLOGIST_AGENT, "foundation:basePrompt")
+            .unwrap_or_default()
+            .unwrap_or_default();
+        let system_prompt = if agent_prompt.is_empty() {
+            base
+        } else {
+            format!("{}\n\n{}", base, agent_prompt)
+        };
+
+        let timeout_secs = crate::owl::get_literal_property(conn, ONTOLOGIST_AGENT, "foundation:requestTimeout")
+            .unwrap_or_default()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(EXTRACTION_TIMEOUT_SECS);
+
+        Ok((api_key, model_id, system_prompt, timeout_secs))
+    }).await
+}
+
+fn build_extraction_prompt(from: &str, subject: &str, body: &str) -> String {
+    let body_truncated = if body.len() > MAX_EMAIL_BODY_CHARS {
+        &body[..MAX_EMAIL_BODY_CHARS]
+    } else {
+        body
+    };
+    format!(
+        "## Email\n\nFrom: {from}\nSubject: {subject}\n\nBody:\n{body}\n\n\
+        ## Task\n\n\
+        Analyze the email. Identify concrete entities that should be created in the knowledge graph.\n\
+        Use `search` and `describe_class` to look up relevant class schemas before extracting.\n\
+        Return ONLY a raw JSON array (no markdown, no explanation). Each item:\n\
+        {{\"class_iri\":\"foundation:ClassName\",\"label\":\"entity name\",\
+        \"properties\":{{\"foundation:propName\":\"value\"}},\"confidence\":0.0}}\n\n\
+        - confidence: 0.0-1.0 (certainty this entity is real and relevant)\n\
+        - Only include concrete, factual entities explicitly mentioned in the email\n\
+        - NEVER use foundation:Email, foundation:EmailAddress, foundation:IMAPAccount or any messaging/infrastructure class\n\
+        - Use only property IRIs confirmed via describe_class\n\
+        - dateTime values must be ISO 8601 format (e.g. \"2026-04-24T09:30:00\")\n\
+        - Return [] if no relevant domain entities found",
+        from = from,
+        subject = subject,
+        body = body_truncated
+    )
+}
+
+fn parse_extraction_response(content: &str) -> Result<Vec<ExtractionItem>, String> {
+    let start = content.find('[').ok_or("no JSON array in response")?;
+    let end = content.rfind(']').ok_or("no JSON array end in response")?;
+    serde_json::from_str(&content[start..=end]).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/imap/extractor.rs
+++ b/src-tauri/src/imap/extractor.rs
@@ -1,0 +1,140 @@
+use rusqlite;
+use crate::eavto::Connection;
+use crate::owl::{Individual, Object};
+
+const STATUS_UNREAD: &str = "foundation:Status_1776975614793";
+
+pub struct ParsedEmail {
+    pub message_id: String,
+    pub from: String,
+    pub to: Vec<String>,
+    pub subject: String,
+    pub date: Option<String>,
+    pub body: String,
+    pub attachment_names: Vec<String>,
+}
+
+pub fn store_email(
+    conn: &mut Connection,
+    account_iri: &str,
+    email: &ParsedEmail,
+) -> Result<Option<String>, String> {
+    if email_exists(conn, &email.message_id) {
+        return Ok(None);
+    }
+
+    let from_iri = ensure_email_address(conn, &email.from)?;
+
+    let to_iris: Vec<Object> = email
+        .to
+        .iter()
+        .filter_map(|addr| ensure_email_address(conn, addr).ok())
+        .map(|iri| Object::Iri(iri))
+        .collect();
+
+    let ts = chrono::Utc::now().timestamp_millis();
+    let email_iri = format!("foundation:Email_{}", ts);
+    let label = if email.subject.is_empty() {
+        "(sem assunto)".to_string()
+    } else {
+        email.subject.chars().take(80).collect()
+    };
+
+    let ind = Individual::new(&email_iri);
+    ind.assert(conn, "foundation:Email", &label, "mark_email_unread", "imap")
+        .map_err(|e| format!("assert email: {}", e))?;
+
+    ind.add_property(conn, "foundation:hasStatus", vec![Object::Iri(STATUS_UNREAD.to_string())], "imap")
+        .map_err(|e| format!("status: {}", e))?;
+    ind.add_property(conn, "foundation:emailMessageId", vec![str_lit(&email.message_id)], "imap")
+        .map_err(|e| format!("messageId: {}", e))?;
+    ind.add_property(conn, "foundation:emailSubject", vec![str_lit(&email.subject)], "imap")
+        .map_err(|e| format!("subject: {}", e))?;
+    ind.add_property(conn, "foundation:emailBody", vec![str_lit(&email.body)], "imap")
+        .map_err(|e| format!("body: {}", e))?;
+    ind.add_property(conn, "foundation:emailFrom", vec![Object::Iri(from_iri)], "imap")
+        .map_err(|e| format!("from: {}", e))?;
+
+    if !to_iris.is_empty() {
+        ind.add_property(conn, "foundation:emailTo", to_iris, "imap")
+            .map_err(|e| format!("to: {}", e))?;
+    }
+
+    if let Some(date) = &email.date {
+        ind.add_property(conn, "foundation:emailDate", vec![datetime_lit(date)], "imap")
+            .map_err(|e| format!("date: {}", e))?;
+    }
+
+    ind.add_property(
+        conn,
+        "foundation:importedFromAccount",
+        vec![Object::Iri(account_iri.to_string())],
+        "imap",
+    )
+    .map_err(|e| format!("account: {}", e))?;
+
+    for name in &email.attachment_names {
+        let att_ts = chrono::Utc::now().timestamp_millis();
+        let att_iri = format!("foundation:EmailAttachment_{}", att_ts);
+        let att = Individual::new(&att_iri);
+        att.assert(conn, "owl:Thing", name, "attach_file", "imap")
+            .map_err(|e| format!("attachment: {}", e))?;
+        ind.add_property(conn, "foundation:emailHasAttachment", vec![Object::Iri(att_iri)], "imap")
+            .map_err(|e| format!("attach link: {}", e))?;
+    }
+
+    Ok(Some(email_iri))
+}
+
+pub fn email_exists(conn: &Connection, message_id: &str) -> bool {
+    find_by_literal(conn, "foundation:emailMessageId", message_id)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+fn ensure_email_address(conn: &mut Connection, address: &str) -> Result<String, String> {
+    let address = address.trim().to_lowercase();
+    if address.is_empty() {
+        return Err("empty email address".to_string());
+    }
+
+    let existing = find_by_literal(conn, "foundation:emailAddress", &address)
+        .unwrap_or_default();
+    if let Some(iri) = existing.into_iter().next() {
+        return Ok(iri);
+    }
+
+    let ts = chrono::Utc::now().timestamp_millis();
+    let iri = format!("foundation:EmailAddress_{}", ts);
+    let ind = Individual::new(&iri);
+    ind.assert(conn, "foundation:EmailAddress", &address, "mail", "imap")
+        .map_err(|e| format!("email address: {}", e))?;
+    ind.add_property(conn, "foundation:emailAddress", vec![str_lit(&address)], "imap")
+        .map_err(|e| format!("emailAddress prop: {}", e))?;
+    Ok(iri)
+}
+
+fn find_by_literal(conn: &Connection, predicate: &str, value: &str) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT subject FROM triples t \
+             WHERE t.predicate = ?1 AND t.object_value = ?2 AND t.retracted = 0 \
+             AND t.tx = (SELECT MAX(tx) FROM triples WHERE subject = t.subject AND predicate = t.predicate) \
+             LIMIT 1",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows: Result<Vec<String>, _> = stmt
+        .query_map(rusqlite::params![predicate, value], |row| row.get(0))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string());
+    rows
+}
+
+fn str_lit(v: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:string".to_string()), language: None }
+}
+
+fn datetime_lit(v: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:dateTime".to_string()), language: None }
+}

--- a/src-tauri/src/imap/mod.rs
+++ b/src-tauri/src/imap/mod.rs
@@ -1,0 +1,15 @@
+pub mod ai_extraction;
+pub mod extractor;
+pub mod sync_worker;
+
+pub(crate) fn log_error(msg: &str) {
+    let path = dirs::data_local_dir()
+        .map(|d| d.join("org.w3id.foundation").join("application.log"));
+    if let Some(path) = path {
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+            let _ = f.write_all(format!("[{}] [BACKEND] [ERROR] {}\n", ts, msg).as_bytes());
+        }
+    }
+}

--- a/src-tauri/src/imap/sync_worker.rs
+++ b/src-tauri/src/imap/sync_worker.rs
@@ -1,0 +1,578 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+use tauri::{AppHandle, Manager};
+use mailparse::MailHeaderMap;
+
+use crate::imap::extractor::{ParsedEmail, store_email};
+use crate::owl::{DbExecutor, Individual, Object};
+
+const DEFAULT_IMAP_PORT: u16 = 993;
+const DEFAULT_SYNC_INTERVAL_MINUTES: i64 = 15;
+const MAX_EMAILS_PER_FETCH: usize = 50;
+const MAX_FAILURES_BEFORE_ALERT: usize = 3;
+const SYNC_SLEEP_MILLIS: u64 = 500;
+const TCP_CONNECT_TIMEOUT_SECS: u64 = 20;
+const TCP_SESSION_READ_TIMEOUT_SECS: u64 = 120;
+
+#[derive(Clone)]
+struct AccountConfig {
+    iri: String,
+    host: String,
+    port: u16,
+    use_tls: bool,
+    username: String,
+    password: String,
+    sync_interval_minutes: i64,
+    monitored_folders: Vec<String>,
+}
+
+pub async fn start_imap_sync(app: AppHandle) {
+    let executor = app.state::<DbExecutor>().inner().clone();
+
+    let accounts = match executor.read(|conn| load_account_configs(conn)).await {
+        Ok(a) => a,
+        Err(_) => return,
+    };
+
+    for account in accounts {
+        spawn_account_sync(executor.clone(), app.clone(), account);
+    }
+}
+
+pub async fn start_account_sync(app: AppHandle, account_iri: String) {
+    let executor = app.state::<DbExecutor>().inner().clone();
+
+    let account = match executor
+        .read(move |conn| {
+            load_account_configs(conn).map(|accounts| {
+                accounts.into_iter().find(|a| a.iri == account_iri)
+            })
+        })
+        .await
+    {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            crate::imap::log_error("IMAP start_account_sync: account not found in configs");
+            return;
+        }
+        Err(e) => {
+            crate::imap::log_error(&format!("IMAP start_account_sync: {}", e));
+            return;
+        }
+    };
+
+    spawn_account_sync(executor, app, account);
+}
+
+fn spawn_account_sync(executor: DbExecutor, app: AppHandle, account: AccountConfig) {
+    tauri::async_runtime::spawn(async move {
+        run_account_loop(executor, app, account).await;
+    });
+}
+
+async fn run_account_loop(executor: DbExecutor, app: AppHandle, account: AccountConfig) {
+    const BACKOFFS: [u64; 3] = [5, 30, 120];
+    let mut failure_count: usize = 0;
+
+    loop {
+        let account_clone = account.clone();
+        let result =
+            tokio::task::spawn_blocking(move || sync_account_blocking(&account_clone)).await;
+
+        match result {
+            Ok(Ok(emails)) => {
+                if failure_count > 0 {
+                    failure_count = 0;
+                    let iri = account.iri.clone();
+                    executor
+                        .write(move |conn| {
+                            Individual::clear_property(conn, &iri, "foundation:lastConnectionError", "imap").ok();
+                            Individual::clear_property(conn, &iri, "foundation:isConnected", "imap").ok();
+                            Individual::new(&iri)
+                                .add_property(conn, "foundation:isConnected", vec![bool_lit(true)], "imap")
+                                .map_err(|e| e.to_string())?;
+                            Ok(String::new())
+                        })
+                        .await
+                        .ok();
+                }
+
+                let mut stored_count: i64 = 0;
+                for email in emails {
+                    let account_iri = account.iri.clone();
+                    let email_from = email.from.clone();
+                    let email_subject = email.subject.clone();
+                    let email_body = email.body.clone();
+                    let subject_log = email.subject.chars().take(40).collect::<String>();
+                    let email_iri = match executor
+                        .write(move |conn| {
+                            store_email(conn, &account_iri, &email)
+                                .map(|opt| opt.unwrap_or_default())
+                        })
+                        .await
+                    {
+                        Ok(s) if !s.is_empty() => { stored_count += 1; Some(s) }
+                        Ok(_) => { crate::imap::log_error(&format!("IMAP: duplicate skipped: {}", subject_log)); None }
+                        Err(e) => { crate::imap::log_error(&format!("IMAP store_email error: {} — {}", subject_log, e)); None }
+                    };
+
+                    if let Some(iri) = email_iri {
+                        let executor_clone = executor.clone();
+                        let app_clone = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            crate::imap::ai_extraction::extract_email_entities(
+                                &app_clone, &executor_clone,
+                                iri, email_subject, email_body, email_from,
+                            ).await;
+                        });
+                    }
+                }
+
+                let account_iri = account.iri.clone();
+                executor
+                    .write(move |conn| write_sync_log(conn, &account_iri, stored_count, None))
+                    .await
+                    .ok();
+
+                // After delivering emails, wait for server push notification before fetching again.
+                let account_for_idle = account.clone();
+                tokio::task::spawn_blocking(move || idle_wait_blocking(&account_for_idle)).await.ok();
+            }
+            err => {
+                let msg = match err {
+                    Ok(Err(e)) => e,
+                    Err(e) => e.to_string(),
+                    Ok(Ok(_)) => unreachable!(),
+                };
+
+                failure_count += 1;
+
+                if failure_count >= MAX_FAILURES_BEFORE_ALERT {
+                    failure_count = 0;
+                    let account_iri = account.iri.clone();
+                    let err_msg = msg.clone();
+                    executor
+                        .write(move |conn| {
+                            write_sync_log(conn, &account_iri, 0, Some(&err_msg)).ok();
+                            record_connection_error(conn, &account_iri, &err_msg)
+                        })
+                        .await
+                        .ok();
+                    crate::imap::log_error(&format!(
+                        "IMAP sync failed for {} after 3 retries: {}",
+                        account.iri, msg
+                    ));
+                    let wait = (account.sync_interval_minutes.max(1) * 60) as u64;
+                    tokio::time::sleep(Duration::from_secs(wait)).await;
+                } else {
+                    let wait = BACKOFFS[(failure_count.saturating_sub(1)).min(2)];
+                    tokio::time::sleep(Duration::from_secs(wait)).await;
+                }
+            }
+        }
+    }
+}
+
+fn write_sync_log(
+    conn: &mut crate::eavto::Connection,
+    account_iri: &str,
+    emails_imported: i64,
+    error: Option<&str>,
+) -> Result<String, String> {
+    let ts = chrono::Utc::now();
+    let ts_ms = ts.timestamp_millis();
+    let ts_iso = ts.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let log_iri = format!("foundation:IMAPSyncLog_{}", ts_ms);
+
+    Individual::new(&log_iri)
+        .assert(conn, "foundation:IMAPSyncLog", &ts_iso, "history", "imap")
+        .map_err(|e| format!("synclog: {}", e))?;
+    Individual::new(&log_iri)
+        .add_property(conn, "foundation:syncStartedAt", vec![datetime_lit(&ts_iso)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&log_iri)
+        .add_property(conn, "foundation:syncEmailsImported", vec![Object::Integer(emails_imported)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&log_iri)
+        .add_property(conn, "foundation:syncForAccount", vec![Object::Iri(account_iri.to_string())], "imap")
+        .map_err(|e| e.to_string())?;
+    if let Some(err) = error {
+        Individual::new(&log_iri)
+            .add_property(conn, "foundation:syncErrorMessage", vec![str_lit(err)], "imap")
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(String::new())
+}
+
+fn datetime_lit(v: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:dateTime".to_string()), language: None }
+}
+
+fn record_connection_error(
+    conn: &mut crate::eavto::Connection,
+    account_iri: &str,
+    error: &str,
+) -> Result<String, String> {
+    Individual::clear_property(conn, account_iri, "foundation:lastConnectionError", "imap").ok();
+    Individual::new(account_iri)
+        .add_property(conn, "foundation:lastConnectionError", vec![str_lit(error)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::clear_property(conn, account_iri, "foundation:isConnected", "imap").ok();
+    Individual::new(account_iri)
+        .add_property(conn, "foundation:isConnected", vec![bool_lit(false)], "imap")
+        .map_err(|e| e.to_string())?;
+
+    let ts = chrono::Utc::now().timestamp_millis();
+    let notif_iri = format!("foundation:AINotification_{}", ts);
+    let title = "Falha na conexão IMAP";
+    Individual::new(&notif_iri)
+        .assert(conn, "foundation:AINotification", title, "warning", "imap")
+        .map_err(|e| format!("notif: {}", e))?;
+    Individual::new(&notif_iri)
+        .add_property(conn, "foundation:hasStatus", vec![Object::Iri("foundation:Pending".to_string())], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&notif_iri)
+        .add_property(conn, "foundation:notificationTitle", vec![str_lit(title)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&notif_iri)
+        .add_property(conn, "foundation:notificationBody", vec![str_lit(error)], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&notif_iri)
+        .add_property(conn, "foundation:notificationType", vec![str_lit("imap_connection_error")], "imap")
+        .map_err(|e| e.to_string())?;
+    Individual::new(&notif_iri)
+        .add_property(conn, "foundation:notificationSource", vec![Object::Iri(account_iri.to_string())], "imap")
+        .map_err(|e| e.to_string())?;
+
+    Ok(String::new())
+}
+
+fn str_lit(v: &str) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:string".to_string()), language: None }
+}
+
+fn bool_lit(v: bool) -> Object {
+    Object::Literal { value: v.to_string(), datatype: Some("xsd:boolean".to_string()), language: None }
+}
+
+fn sync_account_blocking(account: &AccountConfig) -> Result<Vec<ParsedEmail>, String> {
+    if account.use_tls {
+        fetch_tls(account)
+    } else {
+        fetch_plain(account)
+    }
+}
+
+fn idle_wait_blocking(account: &AccountConfig) {
+    let result = if account.use_tls {
+        idle_tls(account)
+    } else {
+        idle_plain(account)
+    };
+    if let Err(e) = result {
+        crate::imap::log_error(&format!("IMAP IDLE error for {}: {}", account.iri, e));
+    }
+}
+
+fn tcp_connect(host: &str, port: u16) -> Result<TcpStream, String> {
+    let addr = std::net::ToSocketAddrs::to_socket_addrs(&(host, port))
+        .map_err(|e| format!("DNS: {}", e))?
+        .next()
+        .ok_or_else(|| format!("DNS: no address for {}", host))?;
+    TcpStream::connect_timeout(&addr, Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS))
+        .map_err(|e| format!("TCP: {}", e))
+}
+
+fn fetch_tls(account: &AccountConfig) -> Result<Vec<ParsedEmail>, String> {
+    let tcp = tcp_connect(&account.host, account.port)?;
+    tcp.set_read_timeout(Some(Duration::from_secs(TCP_SESSION_READ_TIMEOUT_SECS))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(TCP_SESSION_READ_TIMEOUT_SECS))).ok();
+    let tls = native_tls::TlsConnector::new().map_err(|e| e.to_string())?;
+    let tls_stream = tls.connect(&account.host, tcp).map_err(|e| format!("TLS: {}", e))?;
+    let mut session = imap::Client::new(tls_stream)
+        .login(&account.username, &account.password)
+        .map_err(|(e, _)| format!("login: {}", e))?;
+    let emails = sync_folders(&mut session, &account.monitored_folders)?;
+    session.logout().ok();
+    Ok(emails)
+}
+
+fn fetch_plain(account: &AccountConfig) -> Result<Vec<ParsedEmail>, String> {
+    let tcp = tcp_connect(&account.host, account.port)?;
+    tcp.set_read_timeout(Some(Duration::from_secs(TCP_SESSION_READ_TIMEOUT_SECS))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(TCP_SESSION_READ_TIMEOUT_SECS))).ok();
+    let mut session = imap::Client::new(tcp)
+        .login(&account.username, &account.password)
+        .map_err(|(e, _)| format!("login: {}", e))?;
+    let emails = sync_folders(&mut session, &account.monitored_folders)?;
+    session.logout().ok();
+    Ok(emails)
+}
+
+fn idle_tls(account: &AccountConfig) -> Result<(), String> {
+    let tcp = tcp_connect(&account.host, account.port)?;
+    let tls = native_tls::TlsConnector::new().map_err(|e| e.to_string())?;
+    let tls_stream = tls.connect(&account.host, tcp).map_err(|e| format!("TLS: {}", e))?;
+    let mut session = imap::Client::new(tls_stream)
+        .login(&account.username, &account.password)
+        .map_err(|(e, _)| format!("login: {}", e))?;
+    session.select("INBOX").map_err(|e| e.to_string())?;
+    if let Ok(idle) = session.idle() {
+        let _ = idle.wait_keepalive();
+    }
+    session.logout().ok();
+    Ok(())
+}
+
+fn idle_plain(account: &AccountConfig) -> Result<(), String> {
+    let tcp = tcp_connect(&account.host, account.port)?;
+    let mut session = imap::Client::new(tcp)
+        .login(&account.username, &account.password)
+        .map_err(|(e, _)| format!("login: {}", e))?;
+    session.select("INBOX").map_err(|e| e.to_string())?;
+    if let Ok(idle) = session.idle() {
+        let _ = idle.wait_keepalive();
+    }
+    session.logout().ok();
+    Ok(())
+}
+
+fn sync_folders<T: Read + Write>(
+    session: &mut imap::Session<T>,
+    folders: &[String],
+) -> Result<Vec<ParsedEmail>, String> {
+    let folders_to_sync: Vec<&str> = if folders.is_empty() {
+        vec!["INBOX"]
+    } else {
+        folders.iter().map(|s| s.as_str()).collect()
+    };
+
+    let mut all_emails = vec![];
+    for folder in folders_to_sync {
+        session.select(folder).map_err(|e| e.to_string())?;
+        all_emails.extend(fetch_unseen(session)?);
+    }
+    Ok(all_emails)
+}
+
+fn fetch_unseen<T: Read + Write>(session: &mut imap::Session<T>) -> Result<Vec<ParsedEmail>, String> {
+    let uids = session.uid_search("UNSEEN").map_err(|e| e.to_string())?;
+
+    if uids.is_empty() {
+        return Ok(vec![]);
+    }
+    crate::imap::log_error(&format!("IMAP: found {} UNSEEN uid(s): {:?}", uids.len(), uids.iter().take(5).collect::<Vec<_>>()));
+
+    let uid_set: String = uids
+        .iter()
+        .take(MAX_EMAILS_PER_FETCH)
+        .map(|u| u.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let messages = session
+        .uid_fetch(&uid_set, "(UID BODY[])")
+        .map_err(|e| e.to_string())?;
+
+    let mut result = vec![];
+    for msg in messages.iter() {
+        if let Some(body) = msg.body() {
+            match parse_raw_email(body) {
+                Ok(email) => result.push(email),
+                Err(e) => crate::imap::log_error(&format!("IMAP parse error uid={:?}: {}", msg.uid, e)),
+            }
+            continue;
+        }
+        // Fallback: combine RFC822 header + text when BODY[] not available
+        if let (Some(hdr), Some(txt)) = (msg.header(), msg.text()) {
+            crate::imap::log_error(&format!("IMAP: uid={:?} using header+text fallback", msg.uid));
+            let mut combined = Vec::with_capacity(hdr.len() + 2 + txt.len());
+            combined.extend_from_slice(hdr);
+            combined.extend_from_slice(b"\r\n");
+            combined.extend_from_slice(txt);
+            match parse_raw_email(&combined) {
+                Ok(email) => result.push(email),
+                Err(e) => crate::imap::log_error(&format!("IMAP parse error (fallback) uid={:?}: {}", msg.uid, e)),
+            }
+            continue;
+        }
+        crate::imap::log_error(&format!(
+            "IMAP: uid={:?} no body, header={}, text={}",
+            msg.uid, msg.header().is_some(), msg.text().is_some()
+        ));
+    }
+
+    Ok(result)
+}
+
+fn extract_addr(s: &str) -> String {
+    let s = s.trim();
+    if let (Some(a), Some(b)) = (s.find('<'), s.rfind('>')) {
+        if a < b { return s[a+1..b].trim().to_lowercase(); }
+    }
+    s.to_lowercase()
+}
+
+fn extract_first_addr(header: &str) -> String {
+    extract_addr(header)
+}
+
+fn parse_addr_list(header: &str) -> Vec<String> {
+    if header.contains('<') {
+        let mut addrs = vec![];
+        let mut remaining = header;
+        while let Some(a) = remaining.find('<') {
+            if let Some(b) = remaining[a..].find('>') {
+                let addr = remaining[a+1..a+b].trim().to_lowercase();
+                if !addr.is_empty() { addrs.push(addr); }
+                remaining = &remaining[a+b+1..];
+            } else { break; }
+        }
+        addrs
+    } else {
+        header.split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty() && s.contains('@'))
+            .collect()
+    }
+}
+
+fn parse_raw_email(raw: &[u8]) -> Result<ParsedEmail, String> {
+    let parsed = mailparse::parse_mail(raw).map_err(|e| e.to_string())?;
+
+    let message_id = parsed
+        .headers
+        .get_first_value("Message-ID")
+        .map(|id| {
+            id.trim()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        })
+        .unwrap_or_else(|| format!("gen-{}", chrono::Utc::now().timestamp_millis()));
+
+    let from = extract_first_addr(&parsed.headers.get_first_value("From").unwrap_or_default());
+
+    let to: Vec<String> = parse_addr_list(&parsed.headers.get_first_value("To").unwrap_or_default());
+
+    let subject = parsed.headers.get_first_value("Subject").unwrap_or_default();
+
+    let date = parsed
+        .headers
+        .get_first_value("Date")
+        .and_then(|d| mailparse::dateparse(&d).ok())
+        .and_then(|ts| {
+            chrono::DateTime::from_timestamp(ts, 0)
+                .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        });
+
+    let body = extract_body_text(&parsed);
+    let attachment_names = collect_attachment_names(&parsed);
+
+    Ok(ParsedEmail { message_id, from, to, subject, date, body, attachment_names })
+}
+
+fn extract_body_text(mail: &mailparse::ParsedMail) -> String {
+    if mail.subparts.is_empty() {
+        if mail.ctype.mimetype.starts_with("text/") {
+            return mail.get_body().unwrap_or_default();
+        }
+        return String::new();
+    }
+    for part in &mail.subparts {
+        if part.ctype.mimetype == "text/plain" {
+            return part.get_body().unwrap_or_default();
+        }
+    }
+    mail.subparts
+        .first()
+        .and_then(|p| p.get_body().ok())
+        .unwrap_or_default()
+}
+
+fn collect_attachment_names(mail: &mailparse::ParsedMail) -> Vec<String> {
+    mail.subparts
+        .iter()
+        .filter_map(|part| {
+            let disp = part.headers.get_first_value("Content-Disposition")?;
+            if !disp.to_lowercase().starts_with("attachment") {
+                return None;
+            }
+            disp.split(';')
+                .find(|s| s.trim().to_lowercase().starts_with("filename="))
+                .map(|s| {
+                    s.trim()
+                        .splitn(2, '=')
+                        .nth(1)
+                        .unwrap_or("")
+                        .trim_matches('"')
+                        .to_string()
+                })
+        })
+        .collect()
+}
+
+fn load_account_configs(
+    conn: &crate::eavto::Connection,
+) -> Result<Vec<AccountConfig>, String> {
+    let iris =
+        crate::owl::find_entities_with_property(conn, "rdf:type", "foundation:IMAPAccount")
+            .map_err(|e| e.to_string())?;
+
+    let mut configs = vec![];
+    for iri in iris {
+        let host = match crate::owl::get_literal_property(conn, &iri, "foundation:imapHost") {
+            Ok(Some(h)) => h,
+            _ => continue,
+        };
+        let port = crate::owl::get_literal_property(conn, &iri, "foundation:imapPort")
+            .unwrap_or_default()
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(DEFAULT_IMAP_PORT);
+        let use_tls = crate::owl::get_literal_property(conn, &iri, "foundation:imapUseTLS")
+            .unwrap_or_default()
+            .map(|v| v == "true")
+            .unwrap_or(true);
+        let username = crate::owl::get_literal_property(conn, &iri, "foundation:imapUsername")
+            .unwrap_or_default()
+            .unwrap_or_default();
+        let sync_interval_minutes =
+            crate::owl::get_literal_property(conn, &iri, "foundation:syncInterval")
+                .unwrap_or_default()
+                .and_then(|s| s.parse::<i64>().ok())
+                .unwrap_or(DEFAULT_SYNC_INTERVAL_MINUTES);
+
+        let cred_iri =
+            match crate::owl::get_iri_property(conn, &iri, "foundation:hasCredential") {
+                Ok(Some(c)) => c,
+                _ => continue,
+            };
+        let password = match crate::owl::get_literal_property(
+            conn,
+            &cred_iri,
+            "foundation:credentialValue",
+        ) {
+            Ok(Some(p)) => p,
+            _ => continue,
+        };
+
+        let monitored_folders =
+            crate::owl::get_all_literal_properties(conn, &iri, "foundation:imapMonitoredFolders")
+                .unwrap_or_default();
+
+        configs.push(AccountConfig {
+            iri,
+            host,
+            port,
+            use_tls,
+            username,
+            password,
+            sync_interval_minutes,
+            monitored_folders,
+        });
+    }
+
+    Ok(configs)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ai;
 mod mcp;
 pub mod search;
 pub mod process_automation;
+pub mod imap;
 
 #[derive(serde::Serialize)]
 pub struct TripleData {
@@ -204,7 +205,15 @@ pub fn run() {
             commands::entity__resolve_iris,
             commands::local_model::setup__get_local_model_status,
             commands::local_model::setup__download_local_model,
-            commands::local_model::setup__cancel_local_model_download
+            commands::local_model::setup__cancel_local_model_download,
+            commands::imap::imap__save_account,
+            commands::imap::imap__get_accounts,
+            commands::imap::imap__test_connection,
+            commands::imap::imap__list_folders,
+            commands::imap::imap__save_monitored_folders,
+            commands::imap::imap__get_sync_history,
+            commands::imap::imap__start_account_sync,
+            commands::imap::imap__delete_account
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/owl/class.rs
+++ b/src-tauri/src/owl/class.rs
@@ -194,7 +194,7 @@ impl Class {
 
     /// Get all properties for this class (declared, used, and inherited)
     /// Returns Vec<(property_iri, source_class_iri)>
-    fn get_properties(
+    pub fn get_properties(
         conn: &Connection,
         class_iri: &str
     ) -> Result<Vec<(String, String)>> {

--- a/src-tauri/src/owl/individual/mod.rs
+++ b/src-tauri/src/owl/individual/mod.rs
@@ -15,7 +15,7 @@ pub use timestamps::{touch, LAST_UPDATED_AT};
 
 pub use properties::{
     get_all_iri_properties, replace_all_property_iris,
-    get_literal_property, get_iri_property,
+    get_literal_property, get_all_literal_properties, get_iri_property,
     has_property_iri, has_property_literal,
     is_instance_of, find_entities_with_property, find_entities_with_predicate,
 };

--- a/src-tauri/src/owl/individual/properties.rs
+++ b/src-tauri/src/owl/individual/properties.rs
@@ -46,6 +46,19 @@ pub fn get_literal_property(
     Ok(result.triples.first().and_then(|t| t.object.as_literal()).map(|s| s.to_string()))
 }
 
+/// Returns all literal values for a predicate on an entity
+pub fn get_all_literal_properties(
+    conn: &Connection,
+    entity: &str,
+    predicate: &str,
+) -> Result<Vec<String>> {
+    let result = query::get_by_entity_predicate(conn, entity, predicate)?;
+    Ok(result.triples.iter()
+        .filter_map(|t| t.object.as_literal())
+        .map(|s| s.to_string())
+        .collect())
+}
+
 /// Returns the first IRI value of a property for an entity
 pub fn get_iri_property(
     conn: &Connection,

--- a/src-tauri/src/owl/mod.rs
+++ b/src-tauri/src/owl/mod.rs
@@ -30,7 +30,7 @@ pub use crate::eavto::get_stats;
 pub use individual::{
     is_system_locked, set_system_locked, check_system_locked,
     get_all_iri_properties, replace_all_property_iris,
-    get_literal_property, get_iri_property,
+    get_literal_property, get_all_literal_properties, get_iri_property,
     has_property_iri, has_property_literal,
     is_instance_of, find_entities_with_property, find_entities_with_predicate,
     validate_allowed_status, resolve_status_appearance, get_entity_status_info,

--- a/src-tauri/src/process_automation/agent_task.rs
+++ b/src-tauri/src/process_automation/agent_task.rs
@@ -507,3 +507,105 @@ pub async fn execute_agent_task(
         None => Ok(last_text),
     }
 }
+
+/// Non-streaming tool loop for background tasks.
+/// Runs up to `max_loops` iterations: generate → execute tool calls → loop until end_turn.
+/// Returns the final text response.
+pub async fn run_headless_tool_loop(
+    executor: &DbExecutor,
+    provider: &crate::ai::providers::ClaudeProvider,
+    system_prompt: String,
+    initial_message: String,
+    tools: Vec<ClaudeTool>,
+    max_loops: usize,
+) -> Result<String> {
+    use crate::ai::{GenerateRequest, ChatMessage};
+
+    let mut messages = vec![ChatMessage::text("user", initial_message)];
+    let mut final_text = String::new();
+
+    for _ in 0..max_loops {
+        let request = GenerateRequest {
+            messages: messages.clone(),
+            max_tokens: Some(DEFAULT_MAX_TOKENS),
+            temperature: Some(DEFAULT_TEMPERATURE),
+            system: Some(system_prompt.clone()),
+            blackboard_context: None,
+            tools: Some(tools.clone()),
+            supports_web_tools: false,
+            thinking: None,
+            tool_choice: None,
+        };
+
+        let response = provider.generate(request).await
+            .map_err(|e| format!("headless tool loop: {}", e))?;
+
+        let stop_reason = response.stop_reason.clone().unwrap_or_default();
+        final_text = response.content.clone();
+
+        let mut assistant_blocks: Vec<ContentBlock> = Vec::new();
+        if !response.content.is_empty() {
+            assistant_blocks.push(ContentBlock::Text { text: response.content.clone() });
+        }
+        for tc in &response.tool_calls {
+            assistant_blocks.push(ContentBlock::ToolUse {
+                id: tc.id.clone(),
+                name: tc.name.clone(),
+                input: tc.input.clone(),
+            });
+        }
+        messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: MessageContent::ContentBlocks(assistant_blocks),
+        });
+
+        if stop_reason != "tool_use" {
+            break;
+        }
+
+        let mut result_blocks: Vec<ContentBlock> = Vec::new();
+        for tc in &response.tool_calls {
+            let call = FunctionToolCall {
+                name: tc.name.clone(),
+                arguments: tc.input.clone(),
+            };
+            let tc_id = tc.id.clone();
+            let result_json = executor
+                .write(move |conn| {
+                    let r = execute_fn(conn, &call, None, None);
+                    serde_json::to_string(&r).map_err(|e| e.to_string())
+                })
+                .await
+                .unwrap_or_else(|e| format!("\"{}\"", e));
+
+            let tool_result: crate::ai::functions::ToolResult =
+                serde_json::from_str(&result_json).unwrap_or(crate::ai::functions::ToolResult {
+                    success: false,
+                    result: None,
+                    error: Some(result_json.clone()),
+                    concept: None,
+                });
+
+            let content = if tool_result.success {
+                tool_result.result
+                    .map(|v| serde_json::to_string(&v).unwrap_or_else(|_| v.to_string()))
+                    .unwrap_or_default()
+            } else {
+                tool_result.error.unwrap_or_default()
+            };
+
+            result_blocks.push(ContentBlock::ToolResult {
+                tool_use_id: tc_id,
+                content: serde_json::Value::String(content),
+                is_error: Some(!tool_result.success),
+            });
+        }
+
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: MessageContent::ContentBlocks(result_blocks),
+        });
+    }
+
+    Ok(final_text)
+}

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -40,13 +40,29 @@
 	let logMessage = $state('');
 	let logError = $state(false);
 
+	// --- IMAP ---
+	let imapAccounts = $state([]);
+	let imapEditing = $state(null); // null = hidden, 'new' = new form, iri = editing existing
+	let imapForm = $state({ label: '', host: '', port: 993, use_tls: true, username: '', password: '', sync_interval_minutes: 15 });
+	let imapTesting = $state(false);
+	let imapSaving = $state(false);
+	let imapDeleting = $state(false);
+	let imapMessage = $state('');
+	let imapError = $state(false);
+	let imapAvailableFolders = $state([]);
+	let imapSelectedFolders = $state([]);
+	let imapLoadingFolders = $state(false);
+	let imapSyncHistory = $state([]);
+	let imapHistoryAccountIri = $state(null);
+	let imapHasExistingPassword = $state(false);
+
 	$effect(() => {
 		loadAll();
 		return () => { localModelUnlisten?.(); };
 	});
 
 	async function loadAll() {
-		await Promise.all([loadModelData(), loadLogPath(), loadLocalModelStatus()]);
+		await Promise.all([loadModelData(), loadLogPath(), loadLocalModelStatus(), loadImapAccounts()]);
 		await loadApiKeyForService(selectedServiceIri);
 	}
 
@@ -237,6 +253,165 @@
 		}
 	}
 
+	async function loadImapAccounts() {
+		try {
+			imapAccounts = await invoke('imap__get_accounts');
+		} catch {
+			imapAccounts = [];
+		}
+	}
+
+	function startAddImapAccount() {
+		imapEditing = 'new';
+		imapHasExistingPassword = false;
+		imapForm = { label: '', host: '', port: 993, use_tls: true, username: '', password: '', sync_interval_minutes: 15 };
+		imapAvailableFolders = [];
+		imapSelectedFolders = [];
+		imapMessage = '';
+		imapError = false;
+	}
+
+	function startEditImapAccount(account) {
+		imapEditing = account.iri;
+		imapHasExistingPassword = true;
+		imapForm = {
+			label: account.label,
+			host: account.host,
+			port: account.port,
+			use_tls: account.use_tls,
+			username: account.username,
+			password: '',
+			sync_interval_minutes: account.sync_interval_minutes,
+		};
+		imapAvailableFolders = account.monitored_folders ?? [];
+		imapSelectedFolders = account.monitored_folders ?? [];
+		imapMessage = '';
+		imapError = false;
+	}
+
+	function cancelImapEdit() {
+		imapEditing = null;
+		imapHasExistingPassword = false;
+		imapAvailableFolders = [];
+		imapSelectedFolders = [];
+		imapMessage = '';
+		imapError = false;
+	}
+
+	function toggleImapFolder(folder) {
+		if (imapSelectedFolders.includes(folder)) {
+			imapSelectedFolders = imapSelectedFolders.filter(f => f !== folder);
+		} else {
+			imapSelectedFolders = [...imapSelectedFolders, folder];
+		}
+	}
+
+	async function testImapConnection() {
+		imapTesting = true;
+		imapLoadingFolders = false;
+		imapMessage = '';
+		imapError = false;
+		try {
+			const msg = await invoke('imap__test_connection', {
+				host: imapForm.host,
+				port: imapForm.port,
+				useTls: imapForm.use_tls,
+				username: imapForm.username,
+				password: imapForm.password,
+			});
+			imapMessage = msg;
+			imapLoadingFolders = true;
+			try {
+				imapAvailableFolders = await invoke('imap__list_folders', {
+					host: imapForm.host,
+					port: imapForm.port,
+					useTls: imapForm.use_tls,
+					username: imapForm.username,
+					password: imapForm.password,
+				});
+				if (imapSelectedFolders.length === 0) {
+					imapSelectedFolders = imapAvailableFolders.filter(f => f === 'INBOX');
+				}
+			} catch {
+				// ignore folder listing error
+			} finally {
+				imapLoadingFolders = false;
+			}
+		} catch (e) {
+			imapMessage = String(e);
+			imapError = true;
+		} finally {
+			imapTesting = false;
+		}
+	}
+
+	async function saveImapAccount() {
+		imapSaving = true;
+		imapMessage = '';
+		imapError = false;
+		try {
+			const savedIri = await invoke('imap__save_account', {
+				accountIri: imapEditing === 'new' ? null : imapEditing,
+				input: {
+					label: imapForm.label,
+					host: imapForm.host,
+					port: imapForm.port,
+					use_tls: imapForm.use_tls,
+					username: imapForm.username,
+					password: imapForm.password,
+					sync_interval_minutes: imapForm.sync_interval_minutes,
+				},
+			});
+			if (imapSelectedFolders.length > 0) {
+				await invoke('imap__save_monitored_folders', {
+					accountIri: savedIri,
+					folders: imapSelectedFolders,
+				});
+			}
+			imapMessage = 'Conta salva.';
+			imapEditing = null;
+			imapAvailableFolders = [];
+			imapSelectedFolders = [];
+			await loadImapAccounts();
+			invoke('imap__start_account_sync', { accountIri: savedIri });
+		} catch (e) {
+			imapMessage = String(e);
+			imapError = true;
+		} finally {
+			imapSaving = false;
+		}
+	}
+
+	async function toggleImapHistory(accountIri) {
+		if (imapHistoryAccountIri === accountIri) {
+			imapHistoryAccountIri = null;
+			imapSyncHistory = [];
+			return;
+		}
+		imapHistoryAccountIri = accountIri;
+		try {
+			imapSyncHistory = await invoke('imap__get_sync_history', { accountIri, limit: 20 });
+		} catch {
+			imapSyncHistory = [];
+		}
+	}
+
+	async function deleteImapAccount(iri) {
+		imapDeleting = true;
+		imapMessage = '';
+		imapError = false;
+		try {
+			await invoke('imap__delete_account', { accountIri: iri });
+			if (imapEditing === iri) imapEditing = null;
+			await loadImapAccounts();
+		} catch (e) {
+			imapMessage = String(e);
+			imapError = true;
+		} finally {
+			imapDeleting = false;
+		}
+	}
+
 	function handleBackdropClick(e) {
 		if (e.target === e.currentTarget) onClose?.();
 	}
@@ -350,6 +525,126 @@
 				{/if}
 			</section>
 			{/if}
+
+			<section class="settings-section">
+				<h3 class="section-title">Contas de Email (IMAP)</h3>
+
+				{#each imapAccounts as account}
+					<div class="imap-account-row">
+						<span class="material-symbols-outlined imap-status-icon" class:connected={account.is_connected}>
+							{account.is_connected ? 'check_circle' : 'radio_button_unchecked'}
+						</span>
+						<div class="imap-account-info">
+							<span class="imap-account-label">{account.label}</span>
+							<span class="imap-account-host">{account.username}@{account.host}</span>
+						</div>
+						<button class="icon-btn" onclick={() => toggleImapHistory(account.iri)} title="Histórico de sincronização">
+							<span class="material-symbols-outlined">history</span>
+						</button>
+						<button class="icon-btn" onclick={() => startEditImapAccount(account)} title="Editar">
+							<span class="material-symbols-outlined">edit</span>
+						</button>
+						<button class="icon-btn danger" onclick={() => deleteImapAccount(account.iri)} disabled={imapDeleting} title="Remover">
+							<span class="material-symbols-outlined">delete</span>
+						</button>
+					</div>
+					{#if imapHistoryAccountIri === account.iri}
+						<div class="sync-history">
+							{#if imapSyncHistory.length === 0}
+								<p class="hint">Nenhuma sincronização registrada.</p>
+							{:else}
+								<table class="sync-table">
+									<thead>
+										<tr>
+											<th>Data</th>
+											<th>Importados</th>
+											<th>Status</th>
+										</tr>
+									</thead>
+									<tbody>
+										{#each imapSyncHistory as entry}
+											<tr>
+												<td>{entry.started_at.replace('T', ' ').replace('Z', '')}</td>
+												<td>{entry.emails_imported}</td>
+												<td class:sync-error={!!entry.error}>{entry.error ?? 'OK'}</td>
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							{/if}
+						</div>
+					{/if}
+				{/each}
+
+				{#if imapEditing !== null}
+					<div class="imap-form">
+						<input class="text-input" type="text" placeholder="Rótulo (ex: Gmail Pessoal)" bind:value={imapForm.label} />
+						<div class="field-row">
+							<input class="text-input" type="text" placeholder="Host (ex: imap.gmail.com)" bind:value={imapForm.host} style="flex:3" />
+							<input class="text-input" type="number" placeholder="993" bind:value={imapForm.port} style="flex:1;min-width:60px" min="1" max="65535" />
+						</div>
+						<input class="text-input" type="text" placeholder="Usuário" bind:value={imapForm.username} autocomplete="off" />
+						<input
+							class="text-input"
+							type="password"
+							placeholder={imapHasExistingPassword ? '••••••••' : 'Senha'}
+							bind:value={imapForm.password}
+							autocomplete="new-password"
+						/>
+						{#if imapHasExistingPassword}
+							<p class="hint" style="margin-top:2px">Deixe em branco para manter a senha salva.</p>
+						{/if}
+						<div class="field-row imap-options-row">
+							<label class="checkbox-label">
+								<input type="checkbox" bind:checked={imapForm.use_tls} />
+								Usar TLS
+							</label>
+							<label class="checkbox-label" style="margin-left:auto">
+								Sincronizar a cada
+								<input class="text-input interval-input" type="number" bind:value={imapForm.sync_interval_minutes} min="1" max="1440" />
+								min
+							</label>
+						</div>
+						{#if imapAvailableFolders.length > 0}
+						<div class="imap-folders">
+							<p class="hint" style="margin-bottom:4px">Pastas monitoradas:</p>
+							{#each imapAvailableFolders as folder}
+								<label class="checkbox-label folder-label">
+									<input type="checkbox" checked={imapSelectedFolders.includes(folder)} onchange={() => toggleImapFolder(folder)} />
+									{folder}
+								</label>
+							{/each}
+						</div>
+					{:else if imapLoadingFolders}
+						<p class="hint">Carregando pastas…</p>
+					{/if}
+					<div class="field-row">
+							<button class="save-btn ghost" onclick={testImapConnection} disabled={imapTesting || !imapForm.host || !imapForm.username || !imapForm.password}>
+								{imapTesting ? 'Testando…' : 'Testar conexão'}
+							</button>
+							<button class="save-btn" onclick={saveImapAccount} disabled={imapSaving || !imapForm.label || !imapForm.host || !imapForm.username || (!imapHasExistingPassword && !imapForm.password)}>
+								{imapSaving ? 'Salvando…' : 'Salvar'}
+							</button>
+							<button class="icon-btn" onclick={cancelImapEdit} title="Cancelar">
+								<span class="material-symbols-outlined">close</span>
+							</button>
+						</div>
+					</div>
+				{/if}
+
+				{#if imapMessage}
+					<p class="feedback" class:error={imapError}>{imapMessage}</p>
+				{/if}
+
+				{#if imapEditing === null}
+					<div class="field-row">
+						<button class="save-btn ghost" onclick={startAddImapAccount}>
+							<span class="material-symbols-outlined btn-icon">add</span>
+							Adicionar conta
+						</button>
+					</div>
+				{/if}
+			</section>
 
 			<section class="settings-section">
 				<h3 class="section-title">Logs</h3>
@@ -555,5 +850,151 @@
 		font-size: 16px;
 		vertical-align: middle;
 		margin-right: 4px;
+	}
+
+	.save-btn.ghost {
+		background: color-mix(in srgb, var(--color-interactive, #7c6fff) 15%, transparent);
+		color: var(--color-interactive, #7c6fff);
+	}
+
+	.save-btn.ghost:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+
+	.icon-btn {
+		background: none;
+		border: none;
+		color: var(--color-neutral, #888);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 4px;
+		flex-shrink: 0;
+	}
+
+	.icon-btn .material-symbols-outlined {
+		font-size: 18px;
+	}
+
+	.icon-btn.danger {
+		color: #e57373;
+	}
+
+	.icon-btn:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+
+	.imap-account-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 0;
+	}
+
+	.imap-status-icon {
+		font-size: 16px;
+		color: var(--color-neutral, #888);
+		flex-shrink: 0;
+	}
+
+	.imap-status-icon.connected {
+		color: #66bb6a;
+	}
+
+	.sync-history {
+		padding: 8px 0 4px 28px;
+	}
+
+	.sync-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 12px;
+	}
+
+	.sync-table th, .sync-table td {
+		text-align: left;
+		padding: 3px 8px;
+		color: var(--color-text-secondary, #aaa);
+	}
+
+	.sync-table th {
+		font-weight: 600;
+		color: var(--color-text-muted, #888);
+	}
+
+	.sync-table .sync-error {
+		color: var(--color-error, #e57373);
+		max-width: 300px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.imap-account-info {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.imap-account-label {
+		font-size: 13px;
+		color: var(--color-neutral-active, #e0e0e0);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.imap-account-host {
+		font-size: 11px;
+		color: var(--color-neutral, #888);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.imap-form {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 10px 0 4px;
+	}
+
+	.imap-options-row {
+		flex-wrap: wrap;
+		gap: 12px;
+	}
+
+	.checkbox-label {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 13px;
+		color: var(--color-neutral, #888);
+		cursor: pointer;
+	}
+
+	.interval-input {
+		flex: none;
+		width: 52px;
+		display: inline-block;
+		padding: 4px 6px;
+	}
+
+	.imap-folders {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		max-height: 160px;
+		overflow-y: auto;
+		padding: 6px 0;
+	}
+
+	.folder-label {
+		font-size: 12px;
 	}
 </style>

--- a/src/lib/components/widgets/inspector/PropertyList.svelte
+++ b/src/lib/components/widgets/inspector/PropertyList.svelte
@@ -1,6 +1,4 @@
 <script>
-  import { slide } from 'svelte/transition';
-  import { cubicOut } from 'svelte/easing';
   import PropertyDetailItem from './PropertyDetailItem.svelte';
   import BigNumberCard from './BigNumberCard.svelte';
   import PropertyHint from './PropertyHint.svelte';
@@ -72,8 +70,6 @@
     hintVisible = false;
   }
 
-  let optionalCollapsed = $state(true);
-
   function isNumericType(datatype) {
     return datatype === 'xsd:decimal' || datatype === 'xsd:integer' ||
            datatype === 'xsd:int' || datatype === 'xsd:long' ||
@@ -108,6 +104,7 @@
         };
       }
       if (!prop.isEmpty) {
+        acc[prop.property].isEmpty = false;
         acc[prop.property].values.push({
           value: prop.value,
           valueLabel: prop.valueLabel,
@@ -146,14 +143,10 @@
     }
 
     if (isClass) {
-      const required = all.filter(g => requiredFields.includes(g.property));
-      const optional = all.filter(g => !requiredFields.includes(g.property));
       return {
         mode: 'class',
-        required: groupBySource(required),
-        optional: groupBySource(optional),
-        requiredCount: required.length,
-        optionalCount: optional.length,
+        all: groupBySource(all),
+        allCount: all.length,
       };
     } else {
       const calculated = all.filter(g => g.isCalculated);
@@ -214,36 +207,9 @@
 
     {#if sections.mode === 'class'}
 
-      {#if sections.requiredCount > 0}
-        <div class="section">
-          <div class="section-header" use:sticky={{ top: 0 }}>
-            <span class="section-title">Required</span>
-            <span class="section-count">{sections.requiredCount}</span>
-          </div>
-          <div class="section-body">
-            {@render sourceGroups(sections.required, 28)}
-          </div>
-        </div>
-      {/if}
-
-      {#if sections.optionalCount > 0}
-        <div class="section">
-          <button
-            class="section-header collapsible"
-            use:sticky={{ top: 0 }}
-            onclick={() => optionalCollapsed = !optionalCollapsed}
-          >
-            <span class="material-symbols-outlined chevron" class:expanded={!optionalCollapsed}>
-              chevron_right
-            </span>
-            <span class="section-title">Optional</span>
-            <span class="section-count">{sections.optionalCount}</span>
-          </button>
-          {#if !optionalCollapsed}
-            <div class="section-body" transition:slide={{ duration: 300, easing: cubicOut }}>
-              {@render sourceGroups(sections.optional, 28)}
-            </div>
-          {/if}
+      {#if sections.allCount > 0}
+        <div class="section-body">
+          {@render sourceGroups(sections.all)}
         </div>
       {/if}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,5 +28,11 @@ export default defineConfig(async () => ({
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
+    fs: {
+      allow: [
+        ".",
+        "/Users/daniel/GIT/FOUNDATION/node_modules",
+      ],
+    },
   },
 }));


### PR DESCRIPTION
## Summary
- IMAP sync integration with email storage and entity extraction
- Agentic email extraction using `run_headless_tool_loop` (reuses agent_task infrastructure, AI queries schema via `search`/`describe_class` tools)
- Fixed backlink display bug: properties with `rdfs:domain = owl:Thing` were shadowing actual values in `PropertyList.svelte`
- `generate` (non-streaming) now supports tool calls
- `Class::get_properties` made public

## Test plan
- [ ] Configure an IMAP account and trigger sync — emails should appear as `foundation:Email` entities
- [ ] Open an email entity in the inspector — extracted entities should appear as backlinks via `foundation:derivedFromEmail`
- [ ] Open an extracted `foundation:Event` — verify `foundation:eventStartDate` is populated with correct ISO 8601 datetime
- [ ] Verify `PropertyList` shows backlink rows correctly (not hidden by empty placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)